### PR TITLE
Fix login form credential field

### DIFF
--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -15,35 +15,35 @@ class AuthController extends Controller
     }
 
     public function doLogin(Request $request)
-{
-    $cred = $request->validate([
-        'usuario'  => ['required','string'],
-        'password' => ['required','string'],
-    ]);
+    {
+        $cred = $request->validate([
+            'usuario'  => ['required', 'string'],
+            'password' => ['required', 'string'],
+        ]);
 
-    // intenta con el campo 'usuario'
-    $ok = Auth::attempt(
-        ['usuario' => $cred['usuario'], 'password' => $cred['password']],
-        $request->boolean('remember')
-    );
+        // intenta con el campo 'usuario'
+        $ok = Auth::attempt(
+            ['usuario' => $cred['usuario'], 'password' => $cred['password']],
+            $request->boolean('remember')
+        );
 
-    if (!$ok) {
-        return back()->withErrors(['usuario' => 'Credenciales inválidas'])->withInput();
+        if (!$ok) {
+            return back()->withErrors(['usuario' => 'Credenciales inválidas'])->withInput();
+        }
+
+        // muy importante para fijar la sesión
+        $request->session()->regenerate();
+
+        $user = Auth::user();
+
+        return match ($user->rol) {
+            'admin'    => redirect()->route('admin.panel'),
+            'cocinero' => redirect()->route('cocina.panel'),
+            'mesero'   => redirect()->route('meseros.panel'),
+            'cliente'  => redirect()->route('cliente.panel'),
+            default    => redirect()->route('cliente.panel'),
+        };
     }
-
-    // muy importante para fijar la sesión
-    $request->session()->regenerate();
-
-    $user = Auth::user();
-
-    return match ($user->rol) {
-        'admin'    => redirect()->route('admin.panel'),
-        'cocinero' => redirect()->route('cocina.panel'),
-        'mesero'   => redirect()->route('meseros.panel'),
-        'cliente'  => redirect()->route('cliente.panel'),
-        default    => redirect()->route('cliente.panel'),
-    };
-}
 
 
     public function logout(Request $request)

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -80,8 +80,8 @@
 
     <form method="POST" action="{{ url('/login') }}">
       @csrf
-      <label for="correo">Correo</label>
-      <input id="correo" type="email" name="correo" value="{{ old('correo') }}" placeholder="tucorreo@ejemplo.com" required>
+      <label for="usuario">Usuario</label>
+      <input id="usuario" type="text" name="usuario" value="{{ old('usuario') }}" placeholder="Tu usuario" required>
 
       <label for="password">Contraseña</label>
       <input id="password" type="password" name="password" placeholder="Tu contraseña" required>


### PR DESCRIPTION
## Summary
- format the login action to PSR-12 standards for readability
- align the login form with the expected `usuario` credential field used by authentication

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d79e7369d0832d8a39c85fed59406d