### PR TITLE
Fix pedido creation endpoint

### DIFF
--- a/app/Http/Controllers/PedidoController.php
+++ b/app/Http/Controllers/PedidoController.php
@@ -7,9 +7,12 @@ use App\Models\DetallePedido;
 use App\Models\MenuItem;
 use App\Models\Plato;
 use App\Models\Bebida;
+use App\Http\Requests\PedidoStoreRequest;
 
 use Illuminate\Http\Request;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Carbon;
 
 class PedidoController extends Controller
 {
@@ -86,62 +89,46 @@ class PedidoController extends Controller
      *   @OA\Response(response=422, description="Datos inválidos")
      * )
      */
-    public function store(Request $request): JsonResponse
-{
-    $data = $request->validate([
-        // usa cliente_id (como está en la BD)
-        'cliente_id'    => 'required|integer|exists:clientes,id',
-        // restaurant_id es NOT NULL en tu tabla: pásalo o define un default
-        'restaurant_id' => 'sometimes|integer|exists:restaurants,id',
-        'estado'        => 'sometimes|in:pendiente,en_entrega,listo,entregado,cancelado',
+    public function store(PedidoStoreRequest $request): JsonResponse
+    {
+        $data = $request->validated();
 
-        'items'   => 'required|array|min:1',
-        'items.*.id_menu_item'    => 'nullable|integer|exists:menu_items,id',
-        'items.*.nombre_producto' => 'required_without:items.*.id_menu_item|string|max:100',
-        'items.*.precio'          => 'required_without:items.*.id_menu_item|numeric|min:0',
-        'items.*.categoria'       => 'required_without:items.*.id_menu_item|string|max:50',
-        'items.*.cantidad'        => 'required|integer|min:1',
-        'items.*.descripcion'     => 'nullable|string',
-    ]);
+        $pedido = DB::transaction(function () use ($data) {
+            $pedido = Pedido::create([
+                'id_cliente' => $data['id_cliente'],
+                'estado'     => $data['estado'] ?? 'pendiente',
+                'mesa'       => $data['mesa'] ?? null,
+                'fecha'      => Carbon::now(),
+            ]);
 
-    $pedido = Pedido::create([
-        'cliente_id'    => $data['cliente_id'],
-        'restaurant_id' => $data['restaurant_id'] ?? 1, // o el que corresponda
-        'estado'        => $data['estado'] ?? 'pendiente',
-        // NO guardamos mesa/fecha porque no existen en tu tabla
-    ]);
+            foreach ($data['items'] as $item) {
+                $menuItem = null;
+                if (!empty($item['id_menu_item'])) {
+                    $menuItem = MenuItem::find($item['id_menu_item']);
+                }
 
-    foreach ($data['items'] as $it) {
-        $nombre      = $it['nombre_producto'] ?? null;
-        $precio      = $it['precio'] ?? null;
-        $categoria   = $it['categoria'] ?? null;
-        $descripcion = $it['descripcion'] ?? null;
+                $nombre      = $menuItem->nombre ?? $item['nombre_producto'];
+                $precio      = $menuItem->precio ?? $item['precio'];
+                $categoria   = $menuItem->categoria ?? $item['categoria'];
+                $descripcion = $item['descripcion'] ?? ($menuItem->descripcion ?? null);
 
-        if (!empty($it['id_menu_item'])) {
-            $mi = MenuItem::find($it['id_menu_item']);
-            if ($mi) {
-                $nombre      = $mi->nombre;
-                $precio      = $mi->precio;
-                $categoria   = $mi->categoria;
-                $descripcion = $descripcion ?? $mi->descripcion;
+                DetallePedido::create([
+                    'id_pedido'       => $pedido->id,
+                    'nombre_producto' => $nombre,
+                    'precio'          => $precio,
+                    'cantidad'        => (int) $item['cantidad'],
+                    'categoria'       => $categoria,
+                    'descripcion'     => $descripcion,
+                ]);
             }
-        }
 
-        // usa pedido_id (como está en la FK)
-        DetallePedido::create([
-            'pedido_id'       => $pedido->id,
-            'nombre_producto' => $nombre,
-            'precio'          => $precio,
-            'cantidad'        => (int)$it['cantidad'],
-            'categoria'       => $categoria,      // asegúrate que existe esta columna
-            'descripcion'     => $descripcion,    // y esta si la quieres usar
-        ]);
+            return $pedido;
+        });
+
+        $pedido->load(['cliente', 'detalle']);
+
+        return $this->created('Pedido creado', $pedido);
     }
-
-    $pedido->load(['cliente','detalle']);
-
-    return $this->created('Pedido creado', $pedido);
-}
 
     /**
      * @OA\Put(


### PR DESCRIPTION
## Summary
- use the dedicated PedidoStoreRequest to validate incoming payloads
- persist pedidos and detalles with the legacy column names inside a transaction

## Testing
- php artisan test *(fails: vendor directory is missing in the container)*

------
https://chatgpt.com/codex/tasks/task_b_68d8a34f529c832d92eda5bdee8b0054