### PR TITLE
Fix pedido swagger docs and creation

### DIFF
--- a/app/Http/Controllers/PedidoController.php
+++ b/app/Http/Controllers/PedidoController.php
@@ -25,7 +25,11 @@ class PedidoController extends Controller
      *   operationId="PedidosIndex",
      *   summary="Lista de pedidos",
      *   tags={"Pedidos"},
-     *   @OA\Response(response=200, description="OK")
+     *   @OA\Response(
+     *     response=200,
+     *     description="Listado paginado",
+     *     @OA\JsonContent(ref="#/components/schemas/PedidoPaginatedResponse")
+     *   )
      * )
      */
     public function index(Request $request)
@@ -48,8 +52,16 @@ class PedidoController extends Controller
      *   summary="Ver pedido por ID",
      *   tags={"Pedidos"},
      *   @OA\Parameter(name="id", in="path", required=true, @OA\Schema(type="integer")),
-     *   @OA\Response(response=200, description="OK"),
-     *   @OA\Response(response=404, description="No encontrado")
+     *   @OA\Response(
+     *     response=200,
+     *     description="Pedido con detalle",
+     *     @OA\JsonContent(ref="#/components/schemas/PedidoDetailResponse")
+     *   ),
+     *   @OA\Response(
+     *     response=404,
+     *     description="No encontrado",
+     *     @OA\JsonContent(ref="#/components/schemas/ApiErrorResponse")
+     *   )
      * )
      */
     public function show(int $id): JsonResponse
@@ -64,26 +76,19 @@ class PedidoController extends Controller
      *   path="/api/pedidos",
      *   summary="Crear pedido con items",
      *   tags={"Pedidos"},
-     *   @OA\RequestBody(required=true,@OA\JsonContent(
-     *     required={"id_cliente","items","restaurant_id"},
-     *     @OA\Property(property="id_cliente",type="integer",example=1),
-     *     @OA\Property(property="restaurant_id",type="integer",example=1),
-     *     @OA\Property(property="estado",type="string",example="pendiente"),
-     *     @OA\Property(property="items",type="array",
-     *     @OA\Property(property="restaurant_id", type="integer", example=1)
-
-     *       @OA\Items(
-     *         @OA\Property(property="id_menu_item",type="integer",example=2),
-     *         @OA\Property(property="nombre_producto",type="string",example="Limonada"),
-     *         @OA\Property(property="precio",type="number",format="float",example=5.5),
-     *         @OA\Property(property="categoria",type="string",example="bebida"),
-     *         @OA\Property(property="cantidad",type="integer",example=2),
-     *         @OA\Property(property="descripcion",type="string",example="sin azúcar")
-     *       )
-     *     )
-     *   )),
-     *   @OA\Response(response=201, description="Creado"),
-     *   @OA\Response(response=422, description="Datos inválidos")
+     *   @OA\RequestBody(
+     *     required=true,
+     *     @OA\JsonContent(ref="#/components/schemas/PedidoCreateRequest")
+     *   ),
+     *   @OA\Response(
+     *     response=201,
+     *     description="Pedido creado",
+     *     @OA\JsonContent(ref="#/components/schemas/PedidoDetailResponse")
+     *   ),
+     *   @OA\Response(
+     *     response=422,
+     *     description="Datos inválidos"
+     *   )
      * )
      */
     public function store(PedidoStoreRequest $request): JsonResponse
@@ -125,7 +130,7 @@ class PedidoController extends Controller
 
         $pedido->load(['cliente', 'detalle']);
 
-        return $this->created('Solicitud creada', $pedido);
+        return $this->created('Pedido creado', $pedido);
     }
 
     /**
@@ -134,12 +139,24 @@ class PedidoController extends Controller
      *   summary="Actualizar pedido (estado)",
      *   tags={"Pedidos"},
      *   @OA\Parameter(name="id", in="path", required=true, @OA\Schema(type="integer")),
-     *   @OA\RequestBody(@OA\JsonContent(
-   *     @OA\Property(property="estado",type="string",enum={"pendiente","en_entrega","listo","entregado","cancelado"})
-     *   )),
-     *   @OA\Response(response=200, description="OK"),
-     *   @OA\Response(response=404, description="No encontrado"),
-     *   @OA\Response(response=422, description="Datos inválidos")
+     *   @OA\RequestBody(
+     *     required=true,
+     *     @OA\JsonContent(ref="#/components/schemas/PedidoUpdateRequest")
+     *   ),
+     *   @OA\Response(
+     *     response=200,
+     *     description="Pedido actualizado",
+     *     @OA\JsonContent(ref="#/components/schemas/PedidoDetailResponse")
+     *   ),
+     *   @OA\Response(
+     *     response=404,
+     *     description="No encontrado",
+     *     @OA\JsonContent(ref="#/components/schemas/ApiErrorResponse")
+     *   ),
+     *   @OA\Response(
+     *     response=422,
+     *     description="Datos inválidos"
+     *   )
      * )
      */
     public function update(Request $request, int $id): JsonResponse
@@ -162,8 +179,16 @@ class PedidoController extends Controller
      *   summary="Eliminar pedido",
      *   tags={"Pedidos"},
      *   @OA\Parameter(name="id", in="path", required=true, @OA\Schema(type="integer")),
-     *   @OA\Response(response=200, description="Eliminado"),
-     *   @OA\Response(response=404, description="No encontrado")
+     *   @OA\Response(
+     *     response=200,
+     *     description="Eliminado",
+     *     @OA\JsonContent(ref="#/components/schemas/ApiMessageResponse")
+     *   ),
+     *   @OA\Response(
+     *     response=404,
+     *     description="No encontrado",
+     *     @OA\JsonContent(ref="#/components/schemas/ApiErrorResponse")
+     *   )
      * )
      */
     public function destroy(int $id): JsonResponse
@@ -182,8 +207,16 @@ class PedidoController extends Controller
      *   summary="Detalle del pedido",
      *   tags={"Pedidos - Detalle"},
      *   @OA\Parameter(name="id", in="path", required=true, @OA\Schema(type="integer")),
-     *   @OA\Response(response=200, description="OK"),
-     *   @OA\Response(response=404, description="No encontrado")
+     *   @OA\Response(
+     *     response=200,
+     *     description="Detalle listado",
+     *     @OA\JsonContent(ref="#/components/schemas/PedidoItemsResponse")
+     *   ),
+     *   @OA\Response(
+     *     response=404,
+     *     description="No encontrado",
+     *     @OA\JsonContent(ref="#/components/schemas/ApiErrorResponse")
+     *   )
      * )
      */
     public function detalle(int $id): JsonResponse

--- a/app/Models/Pedido.php
+++ b/app/Models/Pedido.php
@@ -11,7 +11,7 @@ class Pedido extends Model
     protected $table = 'pedidos';
     protected $primaryKey = 'id';
 
-    protected $fillable = ['cliente_id', 'estado'];
+    protected $fillable = ['cliente_id', 'restaurant_id', 'estado'];
 
     public function cliente()
     {

--- a/app/Swagger/Schemas.php
+++ b/app/Swagger/Schemas.php
@@ -18,4 +18,171 @@ namespace App\Swagger;
  *   @OA\Property(property="updated_at", type="string", format="date-time")
  * )
  */
+
+/**
+ * @OA\Schema(
+ *   schema="PedidoItemInput",
+ *   type="object",
+ *   required={"cantidad"},
+ *   @OA\Property(property="id_menu_item", type="integer", nullable=true, example=12, description="ID del ítem del menú"),
+ *   @OA\Property(property="nombre_producto", type="string", nullable=true, example="Limonada"),
+ *   @OA\Property(property="precio", type="number", format="float", nullable=true, example=5500),
+ *   @OA\Property(property="categoria", type="string", nullable=true, example="bebida"),
+ *   @OA\Property(property="cantidad", type="integer", example=2),
+ *   @OA\Property(property="descripcion", type="string", nullable=true, example="Sin azúcar")
+ * )
+ */
+
+/**
+ * @OA\Schema(
+ *   schema="PedidoItem",
+ *   type="object",
+ *   @OA\Property(property="id", type="integer", example=101),
+ *   @OA\Property(property="id_pedido", type="integer", example=25),
+ *   @OA\Property(property="nombre_producto", type="string", example="Limonada"),
+ *   @OA\Property(property="precio", type="number", format="float", example=5500),
+ *   @OA\Property(property="categoria", type="string", example="bebida"),
+ *   @OA\Property(property="cantidad", type="integer", example=2),
+ *   @OA\Property(property="descripcion", type="string", nullable=true, example="Sin azúcar")
+ * )
+ */
+
+/**
+ * @OA\Schema(
+ *   schema="Pedido",
+ *   type="object",
+ *   required={"cliente_id","restaurant_id","estado"},
+ *   @OA\Property(property="id", type="integer", example=25),
+ *   @OA\Property(property="cliente_id", type="integer", example=7),
+ *   @OA\Property(property="restaurant_id", type="integer", example=1),
+ *   @OA\Property(property="estado", type="string", example="pendiente"),
+ *   @OA\Property(property="created_at", type="string", format="date-time", example="2024-05-01T12:30:00Z"),
+ *   @OA\Property(property="updated_at", type="string", format="date-time", example="2024-05-01T12:35:00Z")
+ * )
+ */
+
+/**
+ * @OA\Schema(
+ *   schema="PedidoWithRelations",
+ *   type="object",
+ *   allOf={
+ *     @OA\Schema(ref="#/components/schemas/Pedido"),
+ *     @OA\Schema(
+ *       @OA\Property(
+ *         property="cliente",
+ *         type="object",
+ *         nullable=true,
+ *         description="Datos del cliente asociado",
+ *         @OA\Property(property="id", type="integer", example=7),
+ *         @OA\Property(property="nombre", type="string", example="Laura Gómez"),
+ *         @OA\Property(property="telefono", type="string", example="3001112222"),
+ *         @OA\Property(property="correo", type="string", nullable=true, example="cliente@example.com")
+ *       ),
+ *       @OA\Property(
+ *         property="detalle",
+ *         type="array",
+ *         @OA\Items(ref="#/components/schemas/PedidoItem")
+ *       )
+ *     )
+ *   }
+ * )
+ */
+
+/**
+ * @OA\Schema(
+ *   schema="PaginationMeta",
+ *   type="object",
+ *   @OA\Property(property="current_page", type="integer", example=1),
+ *   @OA\Property(property="per_page", type="integer", example=10),
+ *   @OA\Property(property="total", type="integer", example=35),
+ *   @OA\Property(property="last_page", type="integer", example=4)
+ * )
+ */
+
+/**
+ * @OA\Schema(
+ *   schema="PedidoPaginatedResponse",
+ *   type="object",
+ *   @OA\Property(property="message", type="string", example="Listado de pedidos"),
+ *   @OA\Property(
+ *     property="data",
+ *     type="array",
+ *     @OA\Items(ref="#/components/schemas/Pedido")
+ *   ),
+ *   @OA\Property(property="meta", ref="#/components/schemas/PaginationMeta")
+ * )
+ */
+
+/**
+ * @OA\Schema(
+ *   schema="PedidoDetailResponse",
+ *   type="object",
+ *   @OA\Property(property="message", type="string", example="Pedido encontrado"),
+ *   @OA\Property(property="data", ref="#/components/schemas/PedidoWithRelations")
+ * )
+ */
+
+/**
+ * @OA\Schema(
+ *   schema="PedidoItemsResponse",
+ *   type="object",
+ *   @OA\Property(property="message", type="string", example="Detalle listado"),
+ *   @OA\Property(
+ *     property="data",
+ *     type="array",
+ *     @OA\Items(ref="#/components/schemas/PedidoItem")
+ *   )
+ * )
+ */
+
+/**
+ * @OA\Schema(
+ *   schema="PedidoCreateRequest",
+ *   type="object",
+ *   required={"id_cliente","restaurant_id","items"},
+ *   @OA\Property(property="id_cliente", type="integer", example=7),
+ *   @OA\Property(property="restaurant_id", type="integer", example=1),
+ *   @OA\Property(property="estado", type="string", example="pendiente"),
+ *   @OA\Property(
+ *     property="items",
+ *     type="array",
+ *     @OA\Items(ref="#/components/schemas/PedidoItemInput")
+ *   )
+ * )
+ */
+
+/**
+ * @OA\Schema(
+ *   schema="PedidoUpdateRequest",
+ *   type="object",
+ *   @OA\Property(
+ *     property="estado",
+ *     type="string",
+ *     enum={"pendiente","en_entrega","listo","entregado","cancelado"},
+ *     example="en_entrega"
+ *   )
+ * )
+ */
+
+/**
+ * @OA\Schema(
+ *   schema="ApiMessageResponse",
+ *   type="object",
+ *   @OA\Property(property="message", type="string", example="Pedido eliminado")
+ * )
+ */
+
+/**
+ * @OA\Schema(
+ *   schema="ApiErrorResponse",
+ *   type="object",
+ *   @OA\Property(
+ *     property="error",
+ *     type="object",
+ *     @OA\Property(property="code", type="integer", example=404),
+ *     @OA\Property(property="message", type="string", example="No encontrado")
+ *   )
+ * )
+ */
+
 class Schemas {}


### PR DESCRIPTION
## Summary
- align the pedido endpoints' Swagger annotations with the real request and response payloads
- add reusable Pedido schemas (requests, responses, items, pagination and errors) for the API documentation
- allow restaurant_id to be mass assigned so pedido creation works without a 500 error

## Testing
- php -l app/Http/Controllers/PedidoController.php
- php -l app/Models/Pedido.php
- php -l app/Swagger/Schemas.php
- php artisan l5-swagger:generate *(fails: vendor directory not installed in container)*

------
https://chatgpt.com/codex/tasks/task_b_68db1450cb2c832da4a4e9c6f6e0ff53