### PR TITLE
Adjust pedido item payload to match schema

### DIFF
--- a/app/Http/Controllers/PedidoController.php
+++ b/app/Http/Controllers/PedidoController.php
@@ -4,7 +4,6 @@ namespace App\Http\Controllers;
 
 use App\Models\Pedido;
 use App\Models\DetallePedido;
-use App\Models\MenuItem;
 use App\Http\Requests\PedidoStoreRequest; 
 
 use Illuminate\Http\Request;
@@ -25,7 +24,11 @@ class PedidoController extends Controller
      *   operationId="PedidosIndex",
      *   summary="Lista de pedidos",
      *   tags={"Pedidos"},
-     *   @OA\Response(response=200, description="OK")
+     *   @OA\Response(
+     *     response=200,
+     *     description="Listado paginado",
+     *     @OA\JsonContent(ref="#/components/schemas/PedidoPaginatedResponse")
+     *   )
      * )
      */
     public function index(Request $request)
@@ -48,8 +51,16 @@ class PedidoController extends Controller
      *   summary="Ver pedido por ID",
      *   tags={"Pedidos"},
      *   @OA\Parameter(name="id", in="path", required=true, @OA\Schema(type="integer")),
-     *   @OA\Response(response=200, description="OK"),
-     *   @OA\Response(response=404, description="No encontrado")
+     *   @OA\Response(
+     *     response=200,
+     *     description="Pedido con detalle",
+     *     @OA\JsonContent(ref="#/components/schemas/PedidoDetailResponse")
+     *   ),
+     *   @OA\Response(
+     *     response=404,
+     *     description="No encontrado",
+     *     @OA\JsonContent(ref="#/components/schemas/ApiErrorResponse")
+     *   )
      * )
      */
     public function show(int $id): JsonResponse
@@ -64,26 +75,19 @@ class PedidoController extends Controller
      *   path="/api/pedidos",
      *   summary="Crear pedido con items",
      *   tags={"Pedidos"},
-     *   @OA\RequestBody(required=true,@OA\JsonContent(
-     *     required={"id_cliente","items","restaurant_id"},
-     *     @OA\Property(property="id_cliente",type="integer",example=1),
-     *     @OA\Property(property="restaurant_id",type="integer",example=1),
-     *     @OA\Property(property="estado",type="string",example="pendiente"),
-     *     @OA\Property(property="items",type="array",
-     *     @OA\Property(property="restaurant_id", type="integer", example=1)
-
-     *       @OA\Items(
-     *         @OA\Property(property="id_menu_item",type="integer",example=2),
-     *         @OA\Property(property="nombre_producto",type="string",example="Limonada"),
-     *         @OA\Property(property="precio",type="number",format="float",example=5.5),
-     *         @OA\Property(property="categoria",type="string",example="bebida"),
-     *         @OA\Property(property="cantidad",type="integer",example=2),
-     *         @OA\Property(property="descripcion",type="string",example="sin azúcar")
-     *       )
-     *     )
-     *   )),
-     *   @OA\Response(response=201, description="Creado"),
-     *   @OA\Response(response=422, description="Datos inválidos")
+     *   @OA\RequestBody(
+     *     required=true,
+     *     @OA\JsonContent(ref="#/components/schemas/PedidoCreateRequest")
+     *   ),
+     *   @OA\Response(
+     *     response=201,
+     *     description="Pedido creado",
+     *     @OA\JsonContent(ref="#/components/schemas/PedidoDetailResponse")
+     *   ),
+     *   @OA\Response(
+     *     response=422,
+     *     description="Datos inválidos"
+     *   )
      * )
      */
     public function store(PedidoStoreRequest $request): JsonResponse
@@ -92,31 +96,20 @@ class PedidoController extends Controller
 
         $pedido = DB::transaction(function () use ($data) {
             $pedido = Pedido::create([
-
-                'cliente_id' => $data['id_cliente'],
+                'cliente_id'    => $data['cliente_id'],
                 'restaurant_id' => $data['restaurant_id'],
-                'estado'     => $data['estado'] ?? 'pendiente',
+                'estado'        => $data['estado'] ?? 'pendiente',
 
             ]);
 
             foreach ($data['items'] as $item) {
-                $menuItem = null;
-                if (!empty($item['id_menu_item'])) {
-                    $menuItem = MenuItem::find($item['id_menu_item']);
-                }
-
-                $nombre      = $menuItem->nombre ?? $item['nombre_producto'];
-                $precio      = $menuItem->precio ?? $item['precio'];
-                $categoria   = $menuItem->categoria ?? $item['categoria'];
-                $descripcion = $item['descripcion'] ?? ($menuItem->descripcion ?? null);
-
                 DetallePedido::create([
                     'id_pedido'       => $pedido->id,
-                    'nombre_producto' => $nombre,
-                    'precio'          => $precio,
+                    'nombre_producto' => $item['nombre_producto'],
+                    'precio'          => $item['precio'],
                     'cantidad'        => (int) $item['cantidad'],
-                    'categoria'       => $categoria,
-                    'descripcion'     => $descripcion,
+                    'categoria'       => $item['categoria'],
+                    'descripcion'     => $item['descripcion'] ?? null,
                 ]);
             }
 
@@ -125,7 +118,7 @@ class PedidoController extends Controller
 
         $pedido->load(['cliente', 'detalle']);
 
-        return $this->created('Solicitud creada', $pedido);
+        return $this->created('Pedido creado', $pedido);
     }
 
     /**
@@ -134,12 +127,24 @@ class PedidoController extends Controller
      *   summary="Actualizar pedido (estado)",
      *   tags={"Pedidos"},
      *   @OA\Parameter(name="id", in="path", required=true, @OA\Schema(type="integer")),
-     *   @OA\RequestBody(@OA\JsonContent(
-   *     @OA\Property(property="estado",type="string",enum={"pendiente","en_entrega","listo","entregado","cancelado"})
-     *   )),
-     *   @OA\Response(response=200, description="OK"),
-     *   @OA\Response(response=404, description="No encontrado"),
-     *   @OA\Response(response=422, description="Datos inválidos")
+     *   @OA\RequestBody(
+     *     required=true,
+     *     @OA\JsonContent(ref="#/components/schemas/PedidoUpdateRequest")
+     *   ),
+     *   @OA\Response(
+     *     response=200,
+     *     description="Pedido actualizado",
+     *     @OA\JsonContent(ref="#/components/schemas/PedidoDetailResponse")
+     *   ),
+     *   @OA\Response(
+     *     response=404,
+     *     description="No encontrado",
+     *     @OA\JsonContent(ref="#/components/schemas/ApiErrorResponse")
+     *   ),
+     *   @OA\Response(
+     *     response=422,
+     *     description="Datos inválidos"
+     *   )
      * )
      */
     public function update(Request $request, int $id): JsonResponse
@@ -162,8 +167,16 @@ class PedidoController extends Controller
      *   summary="Eliminar pedido",
      *   tags={"Pedidos"},
      *   @OA\Parameter(name="id", in="path", required=true, @OA\Schema(type="integer")),
-     *   @OA\Response(response=200, description="Eliminado"),
-     *   @OA\Response(response=404, description="No encontrado")
+     *   @OA\Response(
+     *     response=200,
+     *     description="Eliminado",
+     *     @OA\JsonContent(ref="#/components/schemas/ApiMessageResponse")
+     *   ),
+     *   @OA\Response(
+     *     response=404,
+     *     description="No encontrado",
+     *     @OA\JsonContent(ref="#/components/schemas/ApiErrorResponse")
+     *   )
      * )
      */
     public function destroy(int $id): JsonResponse
@@ -182,8 +195,16 @@ class PedidoController extends Controller
      *   summary="Detalle del pedido",
      *   tags={"Pedidos - Detalle"},
      *   @OA\Parameter(name="id", in="path", required=true, @OA\Schema(type="integer")),
-     *   @OA\Response(response=200, description="OK"),
-     *   @OA\Response(response=404, description="No encontrado")
+     *   @OA\Response(
+     *     response=200,
+     *     description="Detalle listado",
+     *     @OA\JsonContent(ref="#/components/schemas/PedidoItemsResponse")
+     *   ),
+     *   @OA\Response(
+     *     response=404,
+     *     description="No encontrado",
+     *     @OA\JsonContent(ref="#/components/schemas/ApiErrorResponse")
+     *   )
      * )
      */
     public function detalle(int $id): JsonResponse

--- a/app/Http/Requests/PedidoStoreRequest.php
+++ b/app/Http/Requests/PedidoStoreRequest.php
@@ -6,21 +6,35 @@ use Illuminate\Foundation\Http\FormRequest;
 
 class PedidoStoreRequest extends FormRequest
 {
+    protected function prepareForValidation(): void
+    {
+        $input = $this->all();
+
+        if (array_key_exists('id_cliente', $input) && !array_key_exists('cliente_id', $input)) {
+            $input['cliente_id'] = $input['id_cliente'];
+        }
+
+        if (!array_key_exists('restaurant_id', $input) && app()->bound('current_restaurant_id')) {
+            $restaurantId = app('current_restaurant_id');
+            if ($restaurantId) {
+                $input['restaurant_id'] = $restaurantId;
+            }
+        }
+
+        $this->merge($input);
+    }
+
     public function authorize(): bool { return true; }
     public function rules(): array
     {
         return [
-            'id_cliente' => 'required|integer|exists:clientes,id',
+            'cliente_id' => 'required|integer|exists:clientes,id',
             'restaurant_id' => 'required|integer|exists:restaurants,id',
             'estado'     => 'nullable|in:pendiente,en_entrega,listo,entregado,cancelado',
             'items'      => 'required|array|min:1',
-            // Aceptamos 2 formas:
-            // a) con id_menu_item -> lo resolvemos a nombre/precio/categoria
-            // b) sin id_menu_item -> se envían nombre_producto, precio, categoria
-            'items.*.id_menu_item'   => 'nullable|integer|exists:menu_items,id',
-            'items.*.nombre_producto'=> 'required_without:items.*.id_menu_item|string|max:100',
-            'items.*.precio'         => 'required_without:items.*.id_menu_item|numeric|min:0',
-            'items.*.categoria'      => 'required_without:items.*.id_menu_item|string|max:50',
+            'items.*.nombre_producto'=> 'required|string|max:100',
+            'items.*.precio'         => 'required|numeric|min:0',
+            'items.*.categoria'      => 'required|string|max:50',
             'items.*.cantidad'       => 'required|integer|min:1',
             'items.*.descripcion'    => 'nullable|string',
         ];

--- a/app/Models/Pedido.php
+++ b/app/Models/Pedido.php
@@ -11,13 +11,13 @@ class Pedido extends Model
     protected $table = 'pedidos';
     protected $primaryKey = 'id';
 
-    protected $fillable = ['cliente_id', 'estado'];
+    protected $fillable = ['cliente_id', 'restaurant_id', 'estado'];
 
     public function cliente()
     {
  return $this->belongsTo(\App\Models\Cliente::class, 'cliente_id'); 
     }
-    // columnas reales: id_cliente, fecha, estado, mesa
+    // columnas reales: cliente_id, restaurant_id, estado, created_at, updated_at
 
     public function detalle()
     {

--- a/app/Swagger/Schemas.php
+++ b/app/Swagger/Schemas.php
@@ -18,4 +18,170 @@ namespace App\Swagger;
  *   @OA\Property(property="updated_at", type="string", format="date-time")
  * )
  */
+
+/**
+ * @OA\Schema(
+ *   schema="PedidoItemInput",
+ *   type="object",
+ *   required={"nombre_producto","precio","categoria","cantidad"},
+ *   @OA\Property(property="nombre_producto", type="string", example="Limonada"),
+ *   @OA\Property(property="precio", type="number", format="float", example=5500),
+ *   @OA\Property(property="categoria", type="string", example="bebida"),
+ *   @OA\Property(property="cantidad", type="integer", example=2),
+ *   @OA\Property(property="descripcion", type="string", nullable=true, example="Sin azúcar")
+ * )
+ */
+
+/**
+ * @OA\Schema(
+ *   schema="PedidoItem",
+ *   type="object",
+ *   @OA\Property(property="id", type="integer", example=101),
+ *   @OA\Property(property="id_pedido", type="integer", example=25),
+ *   @OA\Property(property="nombre_producto", type="string", example="Limonada"),
+ *   @OA\Property(property="precio", type="number", format="float", example=5500),
+ *   @OA\Property(property="categoria", type="string", example="bebida"),
+ *   @OA\Property(property="cantidad", type="integer", example=2),
+ *   @OA\Property(property="descripcion", type="string", nullable=true, example="Sin azúcar")
+ * )
+ */
+
+/**
+ * @OA\Schema(
+ *   schema="Pedido",
+ *   type="object",
+ *   required={"cliente_id","restaurant_id","estado"},
+ *   @OA\Property(property="id", type="integer", example=25),
+ *   @OA\Property(property="cliente_id", type="integer", example=7),
+ *   @OA\Property(property="restaurant_id", type="integer", example=1),
+ *   @OA\Property(property="estado", type="string", example="pendiente"),
+ *   @OA\Property(property="created_at", type="string", format="date-time", example="2024-05-01T12:30:00Z"),
+ *   @OA\Property(property="updated_at", type="string", format="date-time", example="2024-05-01T12:35:00Z")
+ * )
+ */
+
+/**
+ * @OA\Schema(
+ *   schema="PedidoWithRelations",
+ *   type="object",
+ *   allOf={
+ *     @OA\Schema(ref="#/components/schemas/Pedido"),
+ *     @OA\Schema(
+ *       @OA\Property(
+ *         property="cliente",
+ *         type="object",
+ *         nullable=true,
+ *         description="Datos del cliente asociado",
+ *         @OA\Property(property="id", type="integer", example=7),
+ *         @OA\Property(property="nombre", type="string", example="Laura Gómez"),
+ *         @OA\Property(property="telefono", type="string", example="3001112222"),
+ *         @OA\Property(property="correo", type="string", nullable=true, example="cliente@example.com")
+ *       ),
+ *       @OA\Property(
+ *         property="detalle",
+ *         type="array",
+ *         @OA\Items(ref="#/components/schemas/PedidoItem")
+ *       )
+ *     )
+ *   }
+ * )
+ */
+
+/**
+ * @OA\Schema(
+ *   schema="PaginationMeta",
+ *   type="object",
+ *   @OA\Property(property="current_page", type="integer", example=1),
+ *   @OA\Property(property="per_page", type="integer", example=10),
+ *   @OA\Property(property="total", type="integer", example=35),
+ *   @OA\Property(property="last_page", type="integer", example=4)
+ * )
+ */
+
+/**
+ * @OA\Schema(
+ *   schema="PedidoPaginatedResponse",
+ *   type="object",
+ *   @OA\Property(property="message", type="string", example="Listado de pedidos"),
+ *   @OA\Property(
+ *     property="data",
+ *     type="array",
+ *     @OA\Items(ref="#/components/schemas/Pedido")
+ *   ),
+ *   @OA\Property(property="meta", ref="#/components/schemas/PaginationMeta")
+ * )
+ */
+
+/**
+ * @OA\Schema(
+ *   schema="PedidoDetailResponse",
+ *   type="object",
+ *   @OA\Property(property="message", type="string", example="Pedido encontrado"),
+ *   @OA\Property(property="data", ref="#/components/schemas/PedidoWithRelations")
+ * )
+ */
+
+/**
+ * @OA\Schema(
+ *   schema="PedidoItemsResponse",
+ *   type="object",
+ *   @OA\Property(property="message", type="string", example="Detalle listado"),
+ *   @OA\Property(
+ *     property="data",
+ *     type="array",
+ *     @OA\Items(ref="#/components/schemas/PedidoItem")
+ *   )
+ * )
+ */
+
+/**
+ * @OA\Schema(
+ *   schema="PedidoCreateRequest",
+ *   type="object",
+ *   required={"cliente_id","restaurant_id","items"},
+ *   @OA\Property(property="cliente_id", type="integer", example=7),
+ *   @OA\Property(property="restaurant_id", type="integer", example=1),
+ *   @OA\Property(property="estado", type="string", example="pendiente"),
+ *   @OA\Property(
+ *     property="items",
+ *     type="array",
+ *     @OA\Items(ref="#/components/schemas/PedidoItemInput")
+ *   )
+ * )
+ */
+
+/**
+ * @OA\Schema(
+ *   schema="PedidoUpdateRequest",
+ *   type="object",
+ *   @OA\Property(
+ *     property="estado",
+ *     type="string",
+ *     enum={"pendiente","en_entrega","listo","entregado","cancelado"},
+ *     example="en_entrega"
+ *   )
+ * )
+ */
+
+/**
+ * @OA\Schema(
+ *   schema="ApiMessageResponse",
+ *   type="object",
+ *   @OA\Property(property="message", type="string", example="Pedido eliminado")
+ * )
+ */
+
+/**
+ * @OA\Schema(
+ *   schema="ApiErrorResponse",
+ *   type="object",
+ *   @OA\Property(
+ *     property="error",
+ *     type="object",
+ *     @OA\Property(property="code", type="integer", example=404),
+ *     @OA\Property(property="message", type="string", example="No encontrado")
+ *   )
+ * )
+ */
+
 class Schemas {}

--- a/resources/views/orden.blade.php
+++ b/resources/views/orden.blade.php
@@ -43,7 +43,7 @@
   <section id="menu" class="grid"></section>
 
   <div class="cart">
-    <div>Cliente ID: <input id="id_cliente" type="number" placeholder="Ej: 12" style="width:110px"></div>
+    <div>Cliente ID: <input id="cliente_id" type="number" placeholder="Ej: 12" style="width:110px"></div>
     <div>Mesa: <input id="mesa" type="text" value="{{ $mesa }}" placeholder="Ej: A1" style="width:80px"></div>
     <div>Total ítems: <strong id="total-items">0</strong></div>
     <button id="btn-ver-carrito" class="secondary">Ver carrito</button>
@@ -60,10 +60,10 @@
     const $btnVerCarrito = document.getElementById('btn-ver-carrito');
     const $mesaInput = document.getElementById('mesa');
     const $mesaTag = document.getElementById('mesa-tag');
-    const $idCliente = document.getElementById('id_cliente');
+    const $clienteId = document.getElementById('cliente_id');
 
     // Carrito simple en memoria
-    const cart = []; // { id_menu_item, nombre, cantidad }
+    const cart = []; // { id_menu_item, nombre, precio, categoria, descripcion, cantidad }
 
     function renderItems(items){
       $menu.innerHTML = '';
@@ -80,15 +80,24 @@
           <p class="muted">Categoría: ${it.categoria ?? '-'}</p>
           <p class="price">$ ${Number(it.precio).toFixed(2)}</p>
           <div class="row">
-            <button data-id="${it.id}" data-nombre="${it.nombre}">Agregar</button>
+            <button
+              data-id="${it.id}"
+              data-nombre="${it.nombre}"
+              data-precio="${it.precio}"
+              data-categoria="${it.categoria ?? ''}"
+              data-descripcion="${it.descripcion ?? ''}"
+            >Agregar</button>
           </div>
         `;
         card.querySelector('button').addEventListener('click', (e)=>{
           const id = parseInt(e.target.dataset.id,10);
           const nombre = e.target.dataset.nombre;
+          const precio = Number(e.target.dataset.precio ?? 0);
+          const categoria = e.target.dataset.categoria || '';
+          const descripcion = e.target.dataset.descripcion || null;
           const found = cart.find(x=>x.id_menu_item===id);
           if (found) found.cantidad += 1;
-          else cart.push({ id_menu_item: id, nombre, cantidad: 1 });
+          else cart.push({ id_menu_item: id, nombre, precio, categoria, descripcion, cantidad: 1 });
           $totalItems.textContent = cart.reduce((a,b)=>a+b.cantidad,0);
         });
         $menu.appendChild(card);
@@ -117,16 +126,22 @@
     });
 
     $btnEnviar.addEventListener('click', async ()=>{
-      const id_cliente = parseInt($idCliente.value,10);
+      const cliente_id = parseInt($clienteId.value,10);
       const mesa = $mesaInput.value.trim();
-      if (!id_cliente) return alert('Debes indicar el ID del cliente.');
+      if (!cliente_id) return alert('Debes indicar el ID del cliente.');
       if (!cart.length) return alert('El carrito está vacío.');
 
       // payload para tu POST /api/pedidos
       const payload = {
-        id_cliente,
+        cliente_id,
         mesa: mesa || null,
-        items: cart.map(x=>({ id_menu_item: x.id_menu_item, cantidad: x.cantidad }))
+        items: cart.map(x=>({
+          nombre_producto: x.nombre,
+          precio: x.precio,
+          categoria: x.categoria || 'sin_categoria',
+          cantidad: x.cantidad,
+          descripcion: x.descripcion || null,
+        }))
       };
 
       try{

--- a/storage/api-docs/api-docs.json
+++ b/storage/api-docs/api-docs.json
@@ -527,11 +527,16 @@
                         "application/json": {
                             "schema": {
                                 "required": [
-                                    "id_cliente",
+                                    "cliente_id",
+                                    "restaurant_id",
                                     "items"
                                 ],
                                 "properties": {
-                                    "id_cliente": {
+                                    "cliente_id": {
+                                        "type": "integer",
+                                        "example": 1
+                                    },
+                                    "restaurant_id": {
                                         "type": "integer",
                                         "example": 1
                                     },
@@ -546,11 +551,13 @@
                                     "items": {
                                         "type": "array",
                                         "items": {
+                                            "required": [
+                                                "nombre_producto",
+                                                "precio",
+                                                "categoria",
+                                                "cantidad"
+                                            ],
                                             "properties": {
-                                                "id_menu_item": {
-                                                    "type": "integer",
-                                                    "example": 2
-                                                },
                                                 "nombre_producto": {
                                                     "type": "string",
                                                     "example": "Limonada"


### PR DESCRIPTION
## Summary
- require each pedido item to include nombre_producto, precio, categoria y cantidad en la validación y al guardar el detalle
- actualizar los esquemas Swagger y el json publicado para eliminar id_menu_item y documentar los campos obligatorios reales
- sincronizar la vista de órdenes para enviar el cuerpo esperado por la API usando la información completa del ítem seleccionado

## Testing
- php -l app/Http/Controllers/PedidoController.php
- php -l app/Http/Requests/PedidoStoreRequest.php
- php -l app/Swagger/Schemas.php


------
https://chatgpt.com/codex/tasks/task_b_68db1450cb2c832da4a4e9c6f6e0ff53