### PR TITLE
Add automated tests for pedidos

### DIFF
--- a/app/Models/DetallePedido.php
+++ b/app/Models/DetallePedido.php
@@ -1,10 +1,12 @@
 <?php
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class DetallePedido extends Model
 {
+    use HasFactory;
     protected $table = 'pedido_detalles';
     // esta tabla SÍ tiene timestamps según la migración
     public $timestamps = true;

--- a/app/Models/MenuItem.php
+++ b/app/Models/MenuItem.php
@@ -2,11 +2,13 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use App\Models\Concerns\BelongsToRestaurant;
 
 class MenuItem extends Model
 {
+    use HasFactory;
     use BelongsToRestaurant;
     protected $table = 'menu_items'; // cambia si tu tabla se llama distinto
 

--- a/app/Models/Pedido.php
+++ b/app/Models/Pedido.php
@@ -2,11 +2,13 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use App\Models\Concerns\BelongsToRestaurant;
 
 class Pedido extends Model
 {
+    use HasFactory;
     use BelongsToRestaurant;
 
     protected $table = 'pedidos';

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -21,7 +21,8 @@
         <env name="APP_ENV" value="testing"/>
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="CACHE_DRIVER" value="array"/>
-        <env name="DB_DATABASE" value="testing"/>
+        <env name="DB_CONNECTION" value="sqlite"/>
+        <env name="DB_DATABASE" value=":memory:"/>
         <env name="MAIL_MAILER" value="array"/>
         <env name="QUEUE_CONNECTION" value="sync"/>
         <env name="SESSION_DRIVER" value="array"/>

--- a/tests/Feature/PedidoApiTest.php
+++ b/tests/Feature/PedidoApiTest.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class PedidoApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function tearDown(): void
+    {
+        app()->forgetInstance('current_restaurant_id');
+        parent::tearDown();
+    }
+
+    public function test_can_list_pedidos_with_totals(): void
+    {
+        $ids = $this->seedPedidoConDetalle();
+
+        $response = $this->getJson('/api/pedidos');
+
+        $response->assertOk()
+            ->assertJsonPath('message', 'Listado de pedidos')
+            ->assertJsonPath('meta.total', 1)
+            ->assertJsonPath('data.0.id', $ids['pedido_id'])
+            ->assertJsonPath('data.0.cliente.id', $ids['cliente_id']);
+
+        $this->assertSame(24000.0, (float) $response->json('data.0.total'));
+        $this->assertSame('Juan Pérez', $response->json('data.0.cliente.nombre_cliente'));
+    }
+
+    public function test_can_show_single_pedido_with_detail(): void
+    {
+        $ids = $this->seedPedidoConDetalle();
+
+        $response = $this->getJson("/api/pedidos/{$ids['pedido_id']}");
+
+        $response->assertOk()
+            ->assertJsonPath('message', 'Pedido encontrado')
+            ->assertJsonPath('data.id', $ids['pedido_id'])
+            ->assertJsonPath('data.detalle.0.cantidad', 2);
+
+        $this->assertSame(24000.0, (float) $response->json('data.total'));
+        $this->assertSame($ids['menu_item_id'], $response->json('data.detalle.0.menu_item_id'));
+    }
+
+    private function seedPedidoConDetalle(): array
+    {
+        $restaurantId = DB::table('restaurants')->insertGetId([
+            'nombre' => 'Restaurante Test',
+            'slug' => 'restaurante-test',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        app()->instance('current_restaurant_id', $restaurantId);
+
+        $clienteId = DB::table('clientes')->insertGetId([
+            'nombre_cliente' => 'Juan Pérez',
+            'telefono' => '3001234567',
+            'direccion' => 'Calle 1 #2-34',
+            'fecha_registro' => now(),
+        ]);
+
+        $menuItemId = DB::table('menu_items')->insertGetId([
+            'nombre' => 'Hamburguesa Clásica',
+            'descripcion' => 'Carne, queso y vegetales frescos',
+            'categoria' => 'plato',
+            'precio' => 12000,
+            'imagen' => null,
+            'disponible' => true,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $pedidoId = DB::table('pedidos')->insertGetId([
+            'restaurant_id' => $restaurantId,
+            'cliente_id' => $clienteId,
+            'estado' => 'pendiente',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        DB::table('pedido_detalles')->insert([
+            'restaurant_id' => $restaurantId,
+            'pedido_id' => $pedidoId,
+            'menu_item_id' => $menuItemId,
+            'cantidad' => 2,
+            'precio_unitario' => 12000,
+            'importe' => 24000,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        return [
+            'restaurant_id' => $restaurantId,
+            'cliente_id' => $clienteId,
+            'menu_item_id' => $menuItemId,
+            'pedido_id' => $pedidoId,
+        ];
+    }
+}
+

--- a/tests/Unit/PedidoModelTest.php
+++ b/tests/Unit/PedidoModelTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\DetallePedido;
+use App\Models\Pedido;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Collection;
+use PHPUnit\Framework\TestCase;
+
+class PedidoModelTest extends TestCase
+{
+    public function test_total_attribute_uses_importe_total_when_present(): void
+    {
+        $pedido = new Pedido();
+        $pedido->setRawAttributes(['importe_total' => 35250.75], true);
+
+        $this->assertSame(35250.75, $pedido->total);
+    }
+
+    public function test_total_attribute_sums_loaded_detalle_relation(): void
+    {
+        $pedido = new Pedido();
+        $pedido->setRelation('detalle', new Collection([
+            new DetallePedido(['importe' => 12000]),
+            new DetallePedido(['importe' => 8500.5]),
+        ]));
+
+        $this->assertSame(20500.5, $pedido->total);
+    }
+
+    public function test_fecha_attribute_formats_created_at(): void
+    {
+        $pedido = new Pedido();
+        $pedido->created_at = Carbon::parse('2024-05-15 18:23:45');
+
+        $this->assertSame('2024-05-15 18:23', $pedido->fecha);
+    }
+}
+


### PR DESCRIPTION
## Summary
- enable factories on pedido-related models and configure the testing database for SQLite in-memory runs
- cover the pedidos API with feature tests that exercise listing and retrieval flows
- add unit tests for the Pedido model accessors to validate totals and formatted timestamps

## Testing
- `composer install` *(fails: GitHub API returned 403 when fetching dependencies, preventing test execution)*

------
https://chatgpt.com/codex/tasks/task_b_68e1eb1dd1d4832d9990fba4c0c9cc0e