### PR TITLE
Fix menu item creation without restaurant id

### DIFF
--- a/app/Models/MenuItem.php
+++ b/app/Models/MenuItem.php
@@ -13,7 +13,13 @@ class MenuItem extends Model
     protected $table = 'menu_items'; // cambia si tu tabla se llama distinto
 
     protected $fillable = [
-        'nombre', 'descripcion', 'categoria', 'precio', 'imagen', 'disponible',
+        'nombre',
+        'descripcion',
+        'categoria',
+        'precio',
+        'imagen',
+        'disponible',
+        'restaurant_id',
     ];
 
     protected $casts = [


### PR DESCRIPTION
## Summary
- allow `restaurant_id` to be mass assigned on menu items so inserts honor the not-null column

## Testing
- php artisan test *(fails: vendor/autoload.php is missing in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68f57e660c3483318937d9d6e0b1704b