### PR TITLE
Handle missing restaurant context binding

### DIFF
--- a/app/Models/Concerns/BelongsToRestaurant.php
+++ b/app/Models/Concerns/BelongsToRestaurant.php
@@ -8,14 +8,25 @@ trait BelongsToRestaurant
     public static function bootBelongsToRestaurant()
     {
         static::addGlobalScope('restaurant', function (Builder $builder) {
-            if ($rid = app('current_restaurant_id')) {
-                $builder->where($builder->getModel()->getTable().'.restaurant_id', $rid);
+            if (app()->bound('current_restaurant_id')) {
+                $rid = app('current_restaurant_id');
+
+                if ($rid !== null) {
+                    $builder->where(
+                        $builder->getModel()->getTable() . '.restaurant_id',
+                        $rid
+                    );
+                }
             }
         });
 
         static::creating(function ($model) {
-            if ($rid = app('current_restaurant_id')) {
-                $model->restaurant_id = $rid;
+            if (app()->bound('current_restaurant_id')) {
+                $rid = app('current_restaurant_id');
+
+                if ($rid !== null) {
+                    $model->restaurant_id = $rid;
+                }
             }
         });
     }

--- a/app/Models/MenuItem.php
+++ b/app/Models/MenuItem.php
@@ -13,7 +13,13 @@ class MenuItem extends Model
     protected $table = 'menu_items'; // cambia si tu tabla se llama distinto
 
     protected $fillable = [
-        'nombre', 'descripcion', 'categoria', 'precio', 'imagen', 'disponible',
+        'nombre',
+        'descripcion',
+        'categoria',
+        'precio',
+        'imagen',
+        'disponible',
+        'restaurant_id',
     ];
 
     protected $casts = [


### PR DESCRIPTION
## Summary
- avoid resolving the `current_restaurant_id` binding when it has not been registered
- keep menu-item queries and creation from throwing binding resolution exceptions that surface as HTTP 500 errors

## Testing
- php artisan test *(fails: vendor/autoload.php is missing in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68f57e660c3483318937d9d6e0b1704b